### PR TITLE
Added link to documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,5 @@ export FRED_GNUPLOT=<PATH TO GNUPLOT>   #e.g. /opt/local/bin/gnuplot
 #### Getting Started
 
 With a copy of FRED compiled, one is now ready to get started. Please see our
-documentation: [Agent-Based Modeling with FRED](raw/master/docs/Agent-Based%20Modeling%20with%20FRED.docx),
-or the power point: [Structured FRED](raw/master/docs/Structured%20FRED.pptm).
+documentation: [Agent-Based Modeling with FRED](https://github.com/PublicHealthDynamicsLab/FRED/raw/refs/heads/FRED-v5.7.0/docs/Agent-Based%20Modeling%20with%20FRED.docx),
+or the power point: [Structured FRED](https://github.com/PublicHealthDynamicsLab/FRED/raw/master/docs/Structured%20FRED.pptm).

--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ export PATH="$FRED_HOME/bin:${PATH}"
 export PATH="$FRED_HOME/pybin/bin:${PATH}"
 export FRED_GNUPLOT=<PATH TO GNUPLOT>   #e.g. /opt/local/bin/gnuplot
 ```
+
+#### Getting Started
+
+With a copy of FRED compiled, one is now ready to get started. Please see our
+documentation: [Agent-Based Modeling with FRED](docs/Agent-Based%20Modeling%20with%20FRED.docx),
+or the power point: [Structured FRED](docs/Structured%20FRED.pptm).

--- a/README.md
+++ b/README.md
@@ -52,5 +52,5 @@ export FRED_GNUPLOT=<PATH TO GNUPLOT>   #e.g. /opt/local/bin/gnuplot
 #### Getting Started
 
 With a copy of FRED compiled, one is now ready to get started. Please see our
-documentation: [Agent-Based Modeling with FRED](docs/Agent-Based%20Modeling%20with%20FRED.docx),
-or the power point: [Structured FRED](docs/Structured%20FRED.pptm).
+documentation: [Agent-Based Modeling with FRED](../raw/master/docs/Agent-Based%20Modeling%20with%20FRED.docx),
+or the power point: [Structured FRED](../raw/master/docs/Structured%20FRED.pptm).

--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ export FRED_GNUPLOT=<PATH TO GNUPLOT>   #e.g. /opt/local/bin/gnuplot
 
 With a copy of FRED compiled, one is now ready to get started. Please see our
 documentation: [Agent-Based Modeling with FRED](https://github.com/PublicHealthDynamicsLab/FRED/raw/refs/heads/FRED-v5.7.0/docs/Agent-Based%20Modeling%20with%20FRED.docx),
-or the power point: [Structured FRED](https://github.com/PublicHealthDynamicsLab/FRED/raw/master/docs/Structured%20FRED.pptm).
+or the power point: [Structured FRED](https://github.com/PublicHealthDynamicsLab/FRED/raw/refs/heads/FRED-v5.7.0/docs/Structured%20FRED.pptm).

--- a/README.md
+++ b/README.md
@@ -52,5 +52,5 @@ export FRED_GNUPLOT=<PATH TO GNUPLOT>   #e.g. /opt/local/bin/gnuplot
 #### Getting Started
 
 With a copy of FRED compiled, one is now ready to get started. Please see our
-documentation: [Agent-Based Modeling with FRED](../raw/master/docs/Agent-Based%20Modeling%20with%20FRED.docx),
-or the power point: [Structured FRED](../raw/master/docs/Structured%20FRED.pptm).
+documentation: [Agent-Based Modeling with FRED](raw/master/docs/Agent-Based%20Modeling%20with%20FRED.docx),
+or the power point: [Structured FRED](raw/master/docs/Structured%20FRED.pptm).


### PR DESCRIPTION
Since there is no "master" or "main" branch, it points to specific release meaning this reference would have to be updated every release. However, it would be good to point a newbie in the right direction. If it's a relative link, it drops on the unhelpful "raw" file page for github. 